### PR TITLE
Use custom parse with mod name different from tag

### DIFF
--- a/lib/markright/utils.ex
+++ b/lib/markright/utils.ex
@@ -77,7 +77,13 @@ defmodule Markright.Utils do
   ##############################################################################
 
   @spec to_parser_module(atom(), list()) :: atom()
-  def to_parser_module(atom, opts \\ []),
+  def to_parser_module(atom, opts \\ [])
+
+  def to_parser_module(_atom, [parser: mod] = opts) do
+    if Code.ensure_loaded?(mod), do: mod, else: opts[:fallback]
+  end
+
+  def to_parser_module(atom, opts),
     do: to_module(Markright.Parsers, atom, opts)
 
   @spec to_finalizer_module(atom(), list()) :: atom()

--- a/lib/markright/utils.ex
+++ b/lib/markright/utils.ex
@@ -101,7 +101,7 @@ defmodule Markright.Utils do
     if Code.ensure_loaded?(mod), do: mod, else: opts[:fallback]
   end
 
-  @spec all_of(atom()) :: [atom()]
+  @spec all_of(atom()| String.t()) :: [atom()]
   def all_of(<<"Elixir."::binary, prefix::binary>>), do: all_of(prefix)
 
   def all_of(prefix) when is_binary(prefix) do
@@ -142,7 +142,6 @@ defmodule Markright.Utils do
   def continuation(:continuation, %Plume{} = plume, {tag, %{} = attrs}) do
     case Plume.callback(Plume.continue(plume, {tag, attrs}), plume.fun) do
       %Plume{} = plume -> apply(to_finalizer_module(tag), :finalize, [plume])
-      other -> raise Markright.Errors.UnexpectedContinuation, value: other
     end
   end
 
@@ -157,7 +156,6 @@ defmodule Markright.Utils do
   def continuation(:empty, %Plume{} = plume, {tag, %{} = attrs}) do
     case Plume.callback(Plume.continue(plume, {tag, attrs, nil}), plume.fun) do
       %Plume{} = plume -> apply(to_finalizer_module(tag), :finalize, [plume])
-      other -> raise Markright.Errors.UnexpectedContinuation, value: other
     end
   end
 

--- a/lib/markright/utils.ex
+++ b/lib/markright/utils.ex
@@ -77,14 +77,15 @@ defmodule Markright.Utils do
   ##############################################################################
 
   @spec to_parser_module(atom(), list()) :: atom()
-  def to_parser_module(atom, opts \\ [])
+  def to_parser_module(atom, opts \\ []) do
+    mod = Keyword.get(opts, :parser)
+    mod =
+      if mod && Code.ensure_loaded?(mod),
+        do: mod,
+        else: opts[:fallback]
 
-  def to_parser_module(_atom, [parser: mod] = opts) do
-    if Code.ensure_loaded?(mod), do: mod, else: opts[:fallback]
+      mod || to_module(Markright.Parsers, atom, opts)
   end
-
-  def to_parser_module(atom, opts),
-    do: to_module(Markright.Parsers, atom, opts)
 
   @spec to_finalizer_module(atom(), list()) :: atom()
   def to_finalizer_module(atom, opts \\ []),

--- a/test/with_syntax_test.exs
+++ b/test/with_syntax_test.exs
@@ -1,0 +1,19 @@
+defmodule Markright.WithSyntax.Test do
+  use ExUnit.Case
+  use Markright.Continuation
+
+  test "Custom parse" do
+    input = ~S"""
+    ( ) item 1
+    ( ) item 2
+    """
+    output = Markright.to_ast(input, nil, syntax: [
+      lead: [choice: {"( )", [parser: CustomParse]}],
+    ])
+    assert output == {:article, %{}, [{:p, %{}, [{nil, %{}, [{:choice, %{}, "item 1"}, {:choice, %{}, "item 2"}]}]}]}
+  end
+end
+
+defmodule CustomParse do
+  use Markright.Helpers.Lead, tag: :choice, lead_and_handler: {"( )", [CustomParse]}
+end


### PR DESCRIPTION
This Pull request fix a bug where the parse attribute is ignored and only find the parse mod using the module name, making impossible to use parsers outside the Markright.Parses namespace or when the mod name differ from the tag name.